### PR TITLE
Fix: Anthill settings not loading and GF value not updating

### DIFF
--- a/anthill-settings.php
+++ b/anthill-settings.php
@@ -162,11 +162,22 @@ function anthill_settings() {
 						<?php
 						foreach ($items as $item) {
 							if (is_object($item) && property_exists($item,'id')) {
+								
 								$fields = property_exists($item, 'Controls')? $item->Controls->detail : array();
+								
 								if (is_object($fields)) {
 									$fields = array($fields);
 								}
-								$nrows = max(1,count($fields));
+								
+                                /**
+                                 * Fields can be null which throws an error, stopping
+                                 * the page from loading.
+                                 */
+                                $nrows = 0;
+                                if (is_countable($fields)) {
+                                    $nrows = max(1,count($fields));
+                                }
+
 								echo '<tr class="field">
 									<td rowspan="'.$nrows.'">'.$item->id.'</td>
 									<td rowspan="'.$nrows.'">'.$item->name.'</td>';

--- a/gravity-forms-anthill-form.php
+++ b/gravity-forms-anthill-form.php
@@ -108,7 +108,7 @@ function gform_form_field_settings_anthill($position, $form_id) {
 	<li class="anthill_field">
 		<label class="section_label">Anthill Field</label>
 		<br />
-		<select id="anthill_field_value" onclick="SetFieldProperty('anthillField', jQuery(this).val());" >
+		<select id="anthill_field_value" onchange="SetFieldProperty('anthillField', jQuery(this).val());" >
 			<option value="">None</option>
 			<option value="location">Location</option>
 	<?php
@@ -126,7 +126,7 @@ function gform_form_field_settings_anthill($position, $form_id) {
 	<li class="anthill_file_type">
 		<label class="section_label">Anthill File Type</label>
 		<br />
-		<select id="anthill_file_type_value" onclick="SetFieldProperty('anthillFileType', jQuery(this).val());" >
+		<select id="anthill_file_type_value" onchange="SetFieldProperty('anthillFileType', jQuery(this).val());" >
 			<option value="">None</option>
 			<?php
 			$options = Anthill::GetAttachmentTypes();


### PR DESCRIPTION
Came across two issues while trying to set this plugin up. Submitting a PR with fixes because I couldn't get the plugin to work.

For context, I am running Gravity Forms version 2.8.12 on WordPress 6.5.5.

## Issue 1
When adding the API details for the first time, the script threw a fatal error due to a lack of data for what I think was contact types.

```
Fatal error: Uncaught TypeError: count): Argument #1 ($value) must be of type Countable|array, null given in /wp-content/plugins/wordpress-gravityforms/anthill-settings.php:177 
```

An `is_countable()` check has been added to get around this. 

## Issue 2
When setting the Anthill field that the form field should map to, the dropdown was not updating the value.

This was down to the wrong event handler being used, so I have corrected that. 